### PR TITLE
Adding a possibility to expose respondent variables (eg. sensor quality, calibration results)

### DIFF
--- a/imotionsApi/DESCRIPTION
+++ b/imotionsApi/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: imotionsApi
 Type: Package
 Title: iMotions Data Library
-Version: 2.1.1
+Version: 2.1.2
 Date: 2020-04-16
 Author: Amandine Grappe, Paolo Masulli
 Maintainer: iMotions <support@imotions.com>

--- a/imotionsApi/R/imotionsApi.R
+++ b/imotionsApi/R/imotionsApi.R
@@ -566,8 +566,9 @@ getAOI <- function(study, AOIId) {
 #' @param stimulus Optional - An imStimulus object as returned from \code{\link{getStimuli}}.
 #' @param AOI Optional - An imAOI object as returned from \code{\link{getAOIs}}.
 #' @param segment Optional - An imSegment object as returned from \code{\link{getSegments}}.
-#' @param keepVariables Optional - A boolean indicating whether respondent variables should be kept (if available),
-#'                      by default only the "group" variable is exposed.
+#' @param keepRespondentVariables Optional - A boolean indicating whether respondent variables should be kept (if they
+#'                                are available). If this has the default value of FALSE, only the "group" variable is
+#'                                exposed.
 #'
 #' @return An imRespondentList object (data.table) with all respondents of interest.
 #' @export
@@ -599,9 +600,9 @@ getAOI <- function(study, AOIId) {
 #' respondents <- imotionsApi::getRespondents(study, AOI = AOIs[1, ], segment = segments[1, ])
 #'
 #' ## Get all respondents in the study and access their available variables
-#' respondents <- imotionsApi::getRespondents(study, keepVariables = TRUE)
+#' respondents <- imotionsApi::getRespondents(study, keepRespondentVariables = TRUE)
 #' }
-getRespondents <- function(study, stimulus = NULL, AOI = NULL, segment = NULL, keepVariables = FALSE) {
+getRespondents <- function(study, stimulus = NULL, AOI = NULL, segment = NULL, keepRespondentVariables = FALSE) {
     assertValid(hasArg(study), "Please specify a study loaded with `imStudy()`")
     assertClass(study, "imStudy", "`study` argument is not an imStudy object")
     assertClass(stimulus, "imStimulus", "`stimulus` argument is not an imStimulus object")
@@ -623,7 +624,7 @@ getRespondents <- function(study, stimulus = NULL, AOI = NULL, segment = NULL, k
         respondents <- respondents[respondents$id %in% segmentStimulusRespondentsId, ]
     }
 
-    if (!keepVariables) {
+    if (!keepRespondentVariables) {
         respondents[, names(respondents) %like% "variables."] <- NULL
     }
 

--- a/imotionsApi/tests/testthat/test-getRespondents.R
+++ b/imotionsApi/tests/testthat/test-getRespondents.R
@@ -138,11 +138,11 @@ test_that("should expose respondent variables if available", {
     study_more_variables$respondents$variables$var1 <- "var1"
     study_more_variables$respondents$variables$var2 <- "var2"
 
-    respondents <- getRespondents(study_more_variables, keepVariables = T)
+    respondents <- getRespondents(study_more_variables, keepRespondentVariables = T)
     expect_identical(names(respondents), c("name", "id", "group", "age", "gender", "variables.var1", "variables.var2"),
                      "Columns with variables should have been created")
 
-    respondents <- getRespondents(study_more_variables, keepVariables = F)
+    respondents <- getRespondents(study_more_variables, keepRespondentVariables = F)
     expect_identical(names(respondents), c("name", "id", "group", "age", "gender"),
                      "No columns with variables should have been created")
 })

--- a/imotionsApi/tests/testthat/test-getRespondents.R
+++ b/imotionsApi/tests/testthat/test-getRespondents.R
@@ -126,10 +126,25 @@ test_that("getRespondents() by segment and AOI", {
 
 test_that("should create a defaut group if none are available", {
     study_no_group <- study
-    study_no_group$respondents$variables$Group <- NULL
+    names(study_no_group$respondents$variables) <- "TEST"
 
     respondents <- getRespondents(study_no_group)
     expect_identical(unique(respondents$group), "Default", "Default group should have been created")
+})
+
+test_that("should expose respondent variables if available", {
+    #Add respondent variables to the study
+    study_more_variables <- study
+    study_more_variables$respondents$variables$var1 <- "var1"
+    study_more_variables$respondents$variables$var2 <- "var2"
+
+    respondents <- getRespondents(study_more_variables, keepVariables = T)
+    expect_identical(names(respondents), c("name", "id", "group", "age", "gender", "variables.var1", "variables.var2"),
+                     "Columns with variables should have been created")
+
+    respondents <- getRespondents(study_more_variables, keepVariables = F)
+    expect_identical(names(respondents), c("name", "id", "group", "age", "gender"),
+                     "No columns with variables should have been created")
 })
 
 context("getRespondent()")


### PR DESCRIPTION
Adding a possibility to expose respondent variables (eg. sensor quality, calibration results) to be used for some particular exports. By default, the respondent object still only includes the group information as it can get quite big otherwise.