### PR TITLE
imotionsApi v2.6.2

### DIFF
--- a/imotionsApi/DESCRIPTION
+++ b/imotionsApi/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: imotionsApi
 Type: Package
 Title: iMotions Data Library
-Version: 2.6.1-0000000000
+Version: 2.6.2-0000000000
 Date: 2020-04-16
 Author: Amandine Grappe, Paolo Masulli
 Maintainer: iMotions <support@imotions.com>


### PR DESCRIPTION
+ Allow insecure upload in case a bucket contains "." in the name.

+ Fix an issue with unzipping not working properly when running scripts locally on windows.