### PR TITLE
imotionsApi v2.9.2 - minor bug fixes and improvements

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,6 +12,9 @@ on:
 
 permissions:
   contents: write
+  checks: write
+  pull-requests: write
+  issues: read
 
 jobs:
   R-test-lint-build-release:

--- a/imotionsApi/DESCRIPTION
+++ b/imotionsApi/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: imotionsApi
 Type: Package
 Title: iMotions R library
-Version: 2.9.1-0000000000
-Date: 2026-09-01
+Version: 2.9.2-0000000000
+Date: 2026-04-22
 Authors@R: c(
 	person("Amandine", "Grappe", role = "aut"),
 	person("Paolo", "Masulli", role = "ctb"),

--- a/imotionsApi/R/imotionsApi.R
+++ b/imotionsApi/R/imotionsApi.R
@@ -370,8 +370,9 @@ getStimulus <- function(study, stimulusId) {
 #' @param study An imStudy object as returned from \code{\link{imStudy}}.
 #' @param stimulus Optional - An imStimulus object as returned from \code{\link{getStimuli}}.
 #' @param respondent Optional - An imRespondent object as returned from \code{\link{getRespondents}}.
-#' @param generateInOutFiles A boolean indicating whether the corresponding InOut files should be generated and linked
-#'                           to each imAOI object.
+#' @param generateInOutFiles Optional - A boolean indicating whether the corresponding InOut files should be generated
+#'                           and linked to each imAOI object.
+#' @param verbose Optional - A boolean indicating whether warnings from privateAOIfiltering should be shown.
 #'
 #' @importFrom tidyr unnest
 #' @return An imAOIList object (data.table) with all AOIs of interest.
@@ -402,13 +403,17 @@ getStimulus <- function(study, stimulusId) {
 #'
 #' print(AOIs$fileId) # a field "fileId" should have been added with the path to the InOut file
 #' }
-getAois <- function(study, stimulus = NULL, respondent = NULL, generateInOutFiles = FALSE) {
+getAois <- function(study, stimulus = NULL, respondent = NULL, generateInOutFiles = FALSE, verbose = FALSE) {
     assertValid(hasArg(study), "Please specify a study loaded with `imStudy()`")
     assertClass(study, "imStudy", "`study` argument is not an imStudy object")
     assertClass(stimulus, "imStimulus", "`stimulus` argument is not an imStimulus object")
     assertClass(respondent, "imRespondent", "`respondent` argument is not an imRespondent object")
 
-    AOIs <- privateAoiFiltering(study, stimulus, respondent)
+    AOIs <- if (verbose) {
+        privateAoiFiltering(study, stimulus, respondent)
+    } else {
+        suppressWarnings(privateAoiFiltering(study, stimulus, respondent))
+    }
 
     if (is.null(AOIs)) {
         return(NULL)
@@ -424,6 +429,11 @@ getAois <- function(study, stimulus = NULL, respondent = NULL, generateInOutFile
             return(NULL)
         } else {
             AOIs <- merge(AOIs, AOIDetails[, c("aoiId", "respId", "fileId", "resultId")], by.x = "id", by.y = "aoiId")
+
+            if (nrow(AOIs) == 0) {
+                warning("The InOut files found do not match any AOIs for this respondent/stimulus combination.")
+                return(NULL)
+            }
         }
     }
 

--- a/imotionsApi/R/imotionsApi.R
+++ b/imotionsApi/R/imotionsApi.R
@@ -1591,7 +1591,7 @@ getAoiRespondentData <- function(study, AOI, respondent) {
         mouseChange <- data[, c(IsMouseInAOI = unique(IsMouseInAOI), .SD[1]), by = rleid(IsMouseInAOI)][, -1]
         mouseChange <- rbind(mouseChange, data[IsMouseDown == TRUE, ])
 
-        inOutMouse <- mouseChange[order(Timestamp), c("Timestamp", "IsMouseInAOI", "IsMouseDown")]
+        inOutMouse <- unique(mouseChange[order(Timestamp), c("Timestamp", "IsMouseInAOI", "IsMouseDown")])
     }
 
     intervals <- intervals[, let(fragments.duration = intervals$fragments.end - intervals$fragments.start,

--- a/imotionsApi/R/imotionsApi.R
+++ b/imotionsApi/R/imotionsApi.R
@@ -994,10 +994,16 @@ getSensorsMetadata <- function(sensors) {
     assertClass(sensors, c("imSensor", "imSensorList"), "`sensors` argument is not an imSensor or imSensorList object")
 
     sensors_metadata <- bind_rows(lapply(sensors$sensorSpecific, function(sensor) {
-        # Add an empty row in case no sensor information was found
-        if (is.na(sensor) || is.null(sensor)) return(data.table(placeholderColumn = NA))
-
-        metadata <- fromJSON(sensor)
+        metadata <- tryCatch(
+            {
+                return(fromJSON(sensor))
+            },
+            error = function(e) {
+                # Add an empty row in case no sensor information was found
+                if (!is.na(sensor) && !is.null(sensor)) warning(sprintf("Malformed JSON detected: %s", sensor))
+                return(data.table(placeholderColumn = NA))
+            }
+        )
 
         # Clean the return json object to create a data.table that can be bind together
         metadata <- metadata[!lengths(metadata) == 0]

--- a/imotionsApi/R/imotionsApi.R
+++ b/imotionsApi/R/imotionsApi.R
@@ -1006,7 +1006,7 @@ getSensorsMetadata <- function(sensors) {
     sensors_metadata <- bind_rows(lapply(sensors$sensorSpecific, function(sensor) {
         metadata <- tryCatch(
             {
-                return(fromJSON(sensor))
+                fromJSON(sensor)
             },
             error = function(e) {
                 # Add an empty row in case no sensor information was found

--- a/imotionsApi/man/getAOIs.Rd
+++ b/imotionsApi/man/getAOIs.Rd
@@ -4,7 +4,13 @@
 \alias{getAois}
 \title{Get AOIs from a study.}
 \usage{
-getAois(study, stimulus = NULL, respondent = NULL, generateInOutFiles = FALSE)
+getAois(
+  study,
+  stimulus = NULL,
+  respondent = NULL,
+  generateInOutFiles = FALSE,
+  verbose = FALSE
+)
 }
 \arguments{
 \item{study}{An imStudy object as returned from \code{\link{imStudy}}.}
@@ -13,8 +19,10 @@ getAois(study, stimulus = NULL, respondent = NULL, generateInOutFiles = FALSE)
 
 \item{respondent}{Optional - An imRespondent object as returned from \code{\link{getRespondents}}.}
 
-\item{generateInOutFiles}{A boolean indicating whether the corresponding InOut files should be generated and linked
-to each imAOI object.}
+\item{generateInOutFiles}{Optional - A boolean indicating whether the corresponding InOut files should be generated
+and linked to each imAOI object.}
+
+\item{verbose}{Optional - A boolean indicating whether warnings from privateAOIfiltering should be shown.}
 }
 \value{
 An imAOIList object (data.table) with all AOIs of interest.

--- a/imotionsApi/tests/testthat/test-getAOIs.R
+++ b/imotionsApi/tests/testthat/test-getAOIs.R
@@ -311,18 +311,25 @@ test_that("remote warning - no in/out was generated", {
 context("getAois()")
 
 mockedGetAois <- function(study, stimulus = NULL, respondent = NULL, generateInOutFiles = FALSE,
-                          expectedCallAoiDetails = 0, expectedCallFiltering = 0, fail = FALSE) {
+                          expectedCallAoiDetails = 0, expectedCallFiltering = 0, fail = FALSE, verbose = TRUE,
+                          wrong_id = FALSE) {
 
     privateAoiFiltering_Stub <- mock(mockedPrivateAoiFiltering(study, stimulus, respondent, expectedCallFiltering))
-    privateGetAoiDetails_Stub <- mock(jsonlite::fromJSON("../data/AOIDetailsForStimulusRespondent.json"))
+
+    # Create the different failing usecases
+    aoi_details <- jsonlite::fromJSON("../data/AOIDetailsForStimulusRespondent.json")
 
     if (fail) {
-        privateGetAoiDetails_Stub <- mock(NULL)
+        aoi_details <- NULL
+    } else if (wrong_id) {
+        aoi_details$aoiId <- "wrong_id"
     }
+
+    privateGetAoiDetails_Stub <- mock(aoi_details)
 
     AOIs <- mockr::with_mock(privateAoiFiltering = privateAoiFiltering_Stub,
                              privateGetAoiDetails = privateGetAoiDetails_Stub, {
-                                 getAois(study, stimulus, respondent, generateInOutFiles)
+                                 getAois(study, stimulus, respondent, generateInOutFiles, verbose)
                              })
 
     expect_args(privateAoiFiltering_Stub, 1, study, stimulus, respondent)
@@ -362,6 +369,26 @@ test_that("error/warning - arguments are missing or not from the good class", {
     expect_warning(mockedGetAois(study, stimulus = NULL, respondents[1, ], generateInOutFiles = TRUE),
                    "InOut files can only be generated when both respondent and stimulus argument are provided.",
                    info = "stimulus argument must be provided")
+})
+
+test_that("check - verbose parameter", {
+    # Private filtering warnings should still be shown by default
+    expect_warning(AOIs <- mockedGetAois(study, respondent = respondents[1, ], stimulus = stimuli[1, ]),
+                   "No AOI defined for respondent: Wendy, stimulus: AntiSmoking40Sec",
+                   info = "private filtering warning should be shown when verbose = TRUE")
+
+    expect_null(AOIs, "AOIs should be null")
+
+    # The same private filtering warning should be silenced when verbose = FALSE
+    expect_no_warning(AOIs <- mockedGetAois(study, respondent = respondents[1, ], stimulus = stimuli[1, ],
+                                            verbose = FALSE))
+
+    expect_null(AOIs, "AOIs should be null")
+
+    # Warnings emitted by getAois() itself should still be shown
+    expect_warning(mockedGetAois(study, respondent = respondents[1, ], generateInOutFiles = TRUE, verbose = FALSE),
+                   "InOut files can only be generated when both respondent and stimulus argument are provided.",
+                   info = "getAois warning should still be shown when verbose = FALSE")
 })
 
 test_that("return - imAOIList object", {
@@ -419,6 +446,14 @@ test_that("check - generateInOutFiles parameter", {
                           expectedCallAoiDetails = 1, fail = TRUE)
 
     expect_null(AOIs, "No AOIs should be returned")
+
+    # If in/out details do not match any AOIs we should not return any AOIs
+    expect_warning(AOIs <- mockedGetAois(study, stimulus = stimuli[4, ], respondent = respondents[1, ],
+                                         generateInOutFiles = TRUE, expectedCallAoiDetails = 1, wrong_id = TRUE),
+                   "The InOut files found do not match any AOIs for this respondent/stimulus combination.",
+                   info = "A mismatch between AOIs and generated in/out files should send a warning")
+
+    expect_null(AOIs, "No AOIs should be returned when in/out details do not match any AOIs")
 
     # For remote study, should have the in/out data in case a respondent was provided
     stimuli <- getStimuli(study_cloud)


### PR DESCRIPTION
+ Make sure mouse click events aren’t duplicated when they occur simultaneously with entering/exiting an AOI.

+ Add a safeguard against malformed metadata.

+ Add a safeguard for InOut files that don’t match any AOIs (e.g. in some SEP studies).

+ Add a way to silence warning emitted by the **privateAoiFiltering()** function, since having no AOIs for a given respondent/stimulus is often expected. Warnings can still be enabled by setting the new optional **verbose** argument in **getAois()** to TRUE.